### PR TITLE
Fixed pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,9 @@ repos:
       - id: check-symlinks
       - id: check-toml
       - id: check-vcs-permalinks
-      - id: check-xml
       - id: check-yaml
       - id: debug-statements
       - id: destroyed-symlinks
-      # - id: detect-aws-credentials
       - id: detect-private-key
       - id: double-quote-string-fixer
       - id: end-of-file-fixer
@@ -42,41 +40,11 @@ repos:
     rev: "v1.10.0"
     hooks:
       - id: python-use-type-annotations
-  # Clang-format for formatting C, C++, and JavaScript files
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v21.1.0"
-    hooks:
-      - id: clang-format
-  # ESLint for linting JavaScript and TypeScript files
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: "v9.35.0"
-    hooks:
-      - id: eslint
   # Runs mypy to check Python type annotations.
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.18.1"
     hooks:
       - id: mypy
-  # Lints SCSS files to enforce style and best practices.
-  - repo: https://github.com/pre-commit/mirrors-scss-lint
-    rev: "v0.60.0"
-    hooks:
-      - id: scss-lint
-  # Runs JSHint to analyze JavaScript code for potential errors.
-  - repo: https://github.com/pre-commit/mirrors-jshint
-    rev: "v2.13.6"
-    hooks:
-      - id: jshint
-  # Uses fixmyjs to automatically fix simple JavaScript issues.
-  - repo: https://github.com/pre-commit/mirrors-fixmyjs
-    rev: "v2.0.0"
-    hooks:
-      - id: fixmyjs
-  # Runs CSSLint to check CSS files for errors and stylistic issues.
-  - repo: https://github.com/pre-commit/mirrors-csslint
-    rev: "v1.0.5"
-    hooks:
-      - id: csslint
   # ShellCheck hook for linting shell scripts
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.11.0.1"
@@ -114,23 +82,6 @@ repos:
     rev: "0.2.2"
     hooks:
       - id: checkmake
-  # SQLFluff for linting and fixing SQL files
-  - repo: https://github.com/sqlfluff/sqlfluff
-    rev: "3.4.2"
-    hooks:
-      - id: sqlfluff-lint
-      - id: sqlfluff-fix
-  # RuboCop for linting Ruby files
-  - repo: https://github.com/rubocop/rubocop
-    rev: "v1.80.2"
-    hooks:
-      - id: rubocop
-  # Terraform-py for formatting and validating Terraform files
-  - repo: https://github.com/AleksaC/terraform-py
-    rev: "v1.13.2"
-    hooks:
-      - id: tf-fmt
-      - id: tf-validate
   # Gitleaks for detecting secrets in Git repositories
   - repo: https://github.com/gitleaks/gitleaks
     rev: "v8.28.0"

--- a/.vscode/dockercompose.code-snippets
+++ b/.vscode/dockercompose.code-snippets
@@ -1,1 +1,0 @@
-/workspaces/gemini-chatbot/snippets/dockercompose.code-snippets

--- a/.vscode/dockerfile.code-snippets
+++ b/.vscode/dockerfile.code-snippets
@@ -1,1 +1,0 @@
-/workspaces/gemini-chatbot/snippets/dockerfile.code-snippets

--- a/.vscode/make.code-snippets
+++ b/.vscode/make.code-snippets
@@ -1,1 +1,0 @@
-/workspaces/gemini-chatbot/snippets/make.code-snippets

--- a/.vscode/python.code-snippets
+++ b/.vscode/python.code-snippets
@@ -1,1 +1,0 @@
-/workspaces/gemini-chatbot/snippets/python.code-snippets

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "cSpell.words": [
-    "checkma"
-  ]
-}

--- a/.vscode/sh.code-snippets
+++ b/.vscode/sh.code-snippets
@@ -1,1 +1,0 @@
-/workspaces/gemini-chatbot/snippets/sh.code-snippets

--- a/src/app.py
+++ b/src/app.py
@@ -9,22 +9,22 @@ import streamlit as st
 
 def initialize_session():
     """ Initialize session state variables. """
-    if "messages" not in st.session_state:
-        st.session_state["messages"] = [{
-            "role": "assistant",
-            "content": "How can I help you?"
+    if 'messages' not in st.session_state:
+        st.session_state['messages'] = [{
+            'role': 'assistant',
+            'content': 'How can I help you?'
         }]
-    if "ready" not in st.session_state:
-        st.session_state["ready"] = False
+    if 'ready' not in st.session_state:
+        st.session_state['ready'] = False
 
 
 def validate_inputs(_api_key: str, _model_name: str) -> bool:
     """ Validate if API key and model name are provided. """
     if not _api_key:
-        st.info("Please add your Google API Key to continue...")
+        st.info('Please add your Google API Key to continue...')
         return False
     if not _model_name:
-        st.info("Please select a model to continue...")
+        st.info('Please select a model to continue...')
         return False
     return True
 
@@ -55,49 +55,49 @@ def generate_response(_model: genai.GenerativeModel, _prompt: str) -> str | None
 
 with st.sidebar:
     api_key = st.text_input(
-        label="Google API Key",
-        key="_api_key",
-        type="password",
-        help="Get your API key from https://aistudio.google.com/apikey",
-        placeholder="Enter your Google API Key",
+        label='Google API Key',
+        key='_api_key',
+        type='password',
+        help='Get your API key from https://aistudio.google.com/apikey',
+        placeholder='Enter your Google API Key',
     )
     model_name = st.selectbox(
-        label="Select Model",
+        label='Select Model',
         options=[
-            "gemini-2.5-pro",
-            "gemini-2.5-flash",
-            "gemini-2.5-flash-lite",
-            "gemini-2.0-flash",
-            "gemini-2.0-flash-lite",
+            'gemini-2.5-pro',
+            'gemini-2.5-flash',
+            'gemini-2.5-flash-lite',
+            'gemini-2.0-flash',
+            'gemini-2.0-flash-lite',
         ],
         index=None,
-        help="Choose a Gemini model"
+        help='Choose a Gemini model'
     )
 
-st.title("💬 Q&A Chatbot")
+st.title('💬 Q&A Chatbot')
 
 initialize_session()
 
 for msg in st.session_state.messages:
-    st.chat_message(msg["role"]).write(msg["content"])
+    st.chat_message(msg['role']).write(msg['content'])
 
 # Only enable chat input if API key and model are set
 INPUT_DISABLED = not validate_inputs(api_key, model_name)
 prompt = st.chat_input(disabled=INPUT_DISABLED)
 
 if prompt and not INPUT_DISABLED:
-    st.session_state.messages.append({"role": "user", "content": prompt})
-    st.chat_message("user").write(prompt)
+    st.session_state.messages.append({'role': 'user', 'content': prompt})
+    st.chat_message('user').write(prompt)
 
     model = get_model(api_key, model_name)
     if model:
         response = generate_response(model, prompt)
         if response:
             st.session_state.messages.append(
-                {"role": "assistant", "content": response})
-            st.chat_message("assistant").write(response)
+                {'role': 'assistant', 'content': response})
+            st.chat_message('assistant').write(response)
         else:
             st.session_state.messages.append(
-                {"role": "assistant", "content": "Sorry, I couldn't process your request."})
-            st.chat_message("assistant").write(
+                {'role': 'assistant', 'content': "Sorry, I couldn't process your request."})
+            st.chat_message('assistant').write(
                 "Sorry, I couldn't process your request.")


### PR DESCRIPTION
This pull request cleans up the `.pre-commit-config.yaml` file by removing several unused or unnecessary hooks. The main focus is on streamlining the pre-commit configuration to only include actively used and relevant checks, which will help speed up pre-commit runs and reduce maintenance overhead.

**Removed unused or redundant pre-commit hooks:**

* Removed various code linting and formatting hooks for languages and tools not currently in use, such as Clang-format, ESLint, SCSS-lint, JSHint, FixMyJS, CSSLint, SQLFluff, RuboCop, and Terraform-py. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L45-L79) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L117-L133)

**Simplified basic checks:**

* Removed the `check-xml` and commented-out `detect-aws-credentials` hooks from the general checks section, further streamlining the configuration.