### PR TITLE
Fixed: Huggingface error

### DIFF
--- a/.github/workflows/huggingface.yaml
+++ b/.github/workflows/huggingface.yaml
@@ -26,4 +26,5 @@ jobs:
           HF_BRANCH: main
         run: |
           git remote add hf https://$HF_USERNAME:$HF_TOKEN@huggingface.co/spaces/$HF_SPACE
+          git remote set-url origin https://$HF_USERNAME:$HF_TOKEN@huggingface.co/spaces/$HF_SPACE
           git push hf master:$HF_BRANCH

--- a/.github/workflows/huggingface.yaml
+++ b/.github/workflows/huggingface.yaml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   sync-to-hub:
     runs-on: ubuntu-latest
+    environment: HF_TOKEN
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/huggingface.yaml
+++ b/.github/workflows/huggingface.yaml
@@ -25,6 +25,5 @@ jobs:
           HF_SPACE: ${{ github.repository }}
           HF_BRANCH: main
         run: |
-          git remote add hf https://$HF_USERNAME:$HF_TOKEN@huggingface.co/spaces/$HF_SPACE
           git remote set-url origin https://$HF_USERNAME:$HF_TOKEN@huggingface.co/spaces/$HF_SPACE
-          git push hf master:$HF_BRANCH
+          git push origin master:$HF_BRANCH


### PR DESCRIPTION
This pull request makes a minor update to the Hugging Face deployment workflow. The change ensures that the `origin` remote is set with proper authentication before pushing code.

- Workflow update:
  * [`.github/workflows/huggingface.yaml`](diffhunk://#diff-6dce2d26d7440fbdf70e354cbd2228f0dd0e91e9891c744b0c9da24d2d1c1c37R29): Adds a command to set the `origin` remote URL with Hugging Face credentials, improving authentication and consistency during deployment.