### PR TITLE
Fix distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN pip install --user --no-cache-dir -r requirements.txt
 COPY src/ .
 
 # Stage 2: Runtime - Create the distroless image
-FROM gcr.io/distroless/python3.12:nonroot
+FROM gcr.io/distroless/python3-debian12:nonroot
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request updates the base image used for the runtime stage in the `Dockerfile` to ensure compatibility with newer Python distributions.

Container image update:

* Changed the runtime base image from `gcr.io/distroless/python3.12:nonroot` to `gcr.io/distroless/python3-debian12:nonroot` in the `Dockerfile` to use the latest supported Python 3 distroless image.