### PR TITLE
Added Docker Image Build Check

### DIFF
--- a/.github/workflows/huggingface-test.yaml
+++ b/.github/workflows/huggingface-test.yaml
@@ -6,7 +6,18 @@ permissions:
   contents: write
   pull-requests: write
 jobs:
+  build-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Build Docker image
+        env:
+          IMAGE_NAME: ${{ github.repository_owner }}/github-test
+        run: |
+          docker build -t $IMAGE_NAME .
   sync-to-hub:
+    needs: build-docker-image
     runs-on: ubuntu-latest
     environment: HF_TOKEN
     steps:


### PR DESCRIPTION
This pull request introduces a new job to the Hugging Face test workflow that builds a Docker image before syncing to the hub. The main goal is to ensure that the Docker image is built and available prior to running the sync job.

Workflow improvements:

* Added a new `build-docker-image` job to the `.github/workflows/huggingface-test.yaml` workflow, which checks out the repository and builds a Docker image using the repository owner and a fixed image name.
* Updated the `sync-to-hub` job to depend on the successful completion of the `build-docker-image` job, ensuring proper job sequencing.