### PR TITLE
Fix Failure Test Build

### DIFF
--- a/.github/workflows/huggingface-test.yaml
+++ b/.github/workflows/huggingface-test.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 0
           lfs: true
       - name: Configure Git
@@ -37,7 +37,7 @@ jobs:
           HF_USERNAME: ${{ github.repository_owner }}
           HF_SPACE: ${{ github.repository_owner }}/github-test
           HF_BRANCH: main
-          PR_BRANCH: ${{ github.head_ref }}
+          PR_BRANCH: ${{ github.ref }}
         run: |
           git remote set-url origin https://$HF_USERNAME:$HF_TOKEN@huggingface.co/spaces/$HF_SPACE
           git push origin $PR_BRANCH:$HF_BRANCH --force


### PR DESCRIPTION
This pull request updates the workflow configuration in `.github/workflows/huggingface-test.yaml` to use the more reliable `github.ref` variable instead of `github.head_ref`. This change helps ensure that the workflow references the correct branch in both the repository checkout and the Hugging Face deployment steps.

Workflow variable updates:

* Changed the repository checkout step to use `github.ref` for the branch reference, improving consistency and reliability in GitHub Actions workflows.
* Updated the Hugging Face deployment step to use `github.ref` for the `PR_BRANCH` environment variable, ensuring the correct branch is pushed to Hugging Face Spaces.